### PR TITLE
Fix invalid conversion from string to int

### DIFF
--- a/sigmadsp_fwgen
+++ b/sigmadsp_fwgen
@@ -93,7 +93,7 @@ class SigmadDSPFirmwareGen(object):
 		self.write(struct.pack("<III", size, type, samplerate_mask))
 
 	def add_data_chunk(self, node, samplerate_mask):
-		addr = int(node.find("Address").text)
+		addr = int(node.find("Address").text, 0)
 		size = int(node.find("Size").text)
 
 		data = node.find("Data").text
@@ -112,7 +112,7 @@ class SigmadDSPFirmwareGen(object):
 
 	def add_control_chunk(self, node, name, samplerate_mask):
 		pname = node.find("Name").text
-		addr = int(node.find("Address").text)
+		addr = int(node.find("Address").text, 0)
 		length = int(node.find("Size").text)
 
 		self.control_chunks.append((name, pname, addr, length, samplerate_mask))


### PR DESCRIPTION
If a string literal is not a integer integral, a base must be provided.

Traceback (most recent call last):
  File "/sigmadsp-genfirmware/./sigmadsp_fwgen", line 195, in <module>
    SigmadDSPFirmwareGen(in_files.items(), sys.argv[-1])
  File "/sigmadsp-genfirmware/./sigmadsp_fwgen", line 32, in __init__
    self.parse_input_file(in_file, samplerate_mask, samplerate)
  File "/sigmadsp-genfirmware/./sigmadsp_fwgen", line 67, in parse_input_file
    self.add_data_chunk(child, samplerate_mask)
  File "/sigmadsp-genfirmware/./sigmadsp_fwgen", line 96, in add_data_chunk
    addr = int(node.find("Address").text)
ValueError: invalid literal for int() with base 10: '0xC000'

Signed-off-by: Bram Vlerick <bram.vlerick@openpixelsystems.org>